### PR TITLE
`cmd+shift+P` shortcut collision with atom's command palette

### DIFF
--- a/keymaps/eclipse-keybindings.cson
+++ b/keymaps/eclipse-keybindings.cson
@@ -20,7 +20,7 @@
   'cmd-e': 'fuzzy-finder:toggle-buffer-finder'
   'cmd-X': 'editor:upper-case'
   'cmd-Y': 'editor:lower-case'
-  'cmd-shift-p': 'bracket-matcher:go-to-matching-bracket'
+  'cmd-shift-b': 'bracket-matcher:go-to-matching-bracket'
   'cmd-shift-c': 'editor:toggle-line-comments'
 
 '.platform-darwin atom-workspace':


### PR DESCRIPTION
Avoiding collision with atom's command pallete shortcut triggered by `cmd+shift+P`